### PR TITLE
Use ESM build for React Native, fix RN test

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,18 +90,7 @@ import { lib } from 'https://cdn.jsdelivr.net/npm/lib/index.js'
 5. Test the result by calling `npx dual-publish --check`.
    It will create a folder in your project with converted files.
    Review them manually.
-6. Until we have [temporary bug](https://github.com/facebook/metro/issues/535)
-   in React Native with `.cjs` you need to tell React Native users to add
-   this lines to `metro.config.js`:
-
-   ```js
-   module.exports = {
-     resolver: {
-      resolverMainFields: ['react-native', 'browser', 'main']
-     }
-   }
-   ```
-7. Publish your project with `npx dual-publish` instead of `npm publish`.
+6. Publish your project with `npx dual-publish` instead of `npm publish`.
 
    ```sh
    npx dual-publish

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "license": "MIT",
   "repository": "ai/dual-publish",
   "devDependencies": {
+    "@babel/core": "^7.9.0",
     "@logux/eslint-config": "^36.1.1",
     "eslint": "^6.8.0",
     "eslint-ci": "^1.0.0",
@@ -45,7 +46,7 @@
     "jest-ci": "^0.1.1",
     "lint-staged": "^10.0.8",
     "metro": "^0.59.0",
-    "metro-core": "^0.59.0",
+    "metro-react-native-babel-transformer": "^0.59.0",
     "nanoid": "^2.1.11",
     "typescript": "^3.8.3",
     "webpack": "^4.42.0",

--- a/process-dir.js
+++ b/process-dir.js
@@ -169,7 +169,7 @@ async function replacePackage (dir, file, files) {
   if (files.includes(file.replace(/\.js$/, '.native.js'))) {
     pkg['react-native'] = 'index.native.js'
   } else {
-    pkg['react-native'] = 'index.cjs.js'
+    pkg['react-native'] = 'index.js'
   }
   await writeFile(pkgFile, JSON.stringify(pkg, null, 2))
 }

--- a/test/fixtures/rn-runner/index.js
+++ b/test/fixtures/rn-runner/index.js
@@ -1,3 +1,3 @@
-let { a } = require('lib/a')
+import { a } from 'lib/a'
 
 a()

--- a/test/fixtures/rn-runner/metro.config.js
+++ b/test/fixtures/rn-runner/metro.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  resolver: {
-    resolverMainFields: ['react-native', 'browser', 'main']
-  }
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,7 +9,7 @@
   dependencies:
     "@babel/highlight" "^7.8.3"
 
-"@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.7.5":
+"@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.7.5", "@babel/core@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.0.tgz#ac977b538b77e132ff706f3b8a4dbad09c03c56e"
   integrity sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==
@@ -4981,7 +4981,7 @@ metro-config@0.59.0:
     metro-cache "0.59.0"
     metro-core "0.59.0"
 
-metro-core@0.59.0, metro-core@^0.59.0:
+metro-core@0.59.0:
   version "0.59.0"
   resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.59.0.tgz#958cde3fe5c8cd84a78e1899af801ad69e9c83b1"
   integrity sha512-kb5LKvV5r2pqMEzGyTid8ai2mIjW13NMduQ8oBmfha7/EPTATcTQ//s+bkhAs1toQD8vqVvjAb0cPNjWQEmcmQ==
@@ -5051,6 +5051,17 @@ metro-react-native-babel-preset@0.59.0:
     "@babel/plugin-transform-unicode-regex" "^7.0.0"
     "@babel/template" "^7.0.0"
     react-refresh "^0.4.0"
+
+metro-react-native-babel-transformer@^0.59.0:
+  version "0.59.0"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.59.0.tgz#9b3dfd6ad35c6ef37fc4ce4d20a2eb67fabbb4be"
+  integrity sha512-1O3wrnMq4NcPQ1asEcl9lRDn/t+F1Oef6S9WaYVIKEhg9m/EQRGVrrTVP+R6B5Eeaj3+zNKbzM8Dx/NWy1hUbQ==
+  dependencies:
+    "@babel/core" "^7.0.0"
+    babel-preset-fbjs "^3.3.0"
+    metro-babel-transformer "0.59.0"
+    metro-react-native-babel-preset "0.59.0"
+    metro-source-map "0.59.0"
 
 metro-resolver@0.59.0:
   version "0.59.0"


### PR DESCRIPTION
I didn't remove `.cjs.js` generation. It may be useful for envs that do not understand `.cjs` extension and consider `file.cjs` as filename.