### PR TITLE
Change regex so 'ws' npm package doesn't get matched

### DIFF
--- a/process-dir.js
+++ b/process-dir.js
@@ -25,7 +25,7 @@ function getPath (file, statement, ext) {
   }
   if (/\.(svg|png|css|sass)["']$/.test(path)) {
     return path
-  } else if (/^["']..?(["']$|\/)/.test(path)) {
+  } else if (/^["']\.\.?(["']$|\/)/.test(path)) {
     if (/\/index\.js(["'])$/.test(path)) {
       return path.replace(/\/index\.js(["'])$/, `/index.${ext}$1`)
     } else if (/\/["']$/.test(path)) {


### PR DESCRIPTION
dual-publish was transforming `require('ws')` into
`require('ws/index.cjs')`, which is wrong.

It appears the regex would match any 2 character npm package name.