### PR TITLE
Keep original package.browser

### DIFF
--- a/process-dir.js
+++ b/process-dir.js
@@ -148,8 +148,12 @@ async function replacePackage(dir, file, files, envTargets) {
   pkg['react-native'] = 'index.js'
 
   if (files.includes(file.replace(/\.js$/, '.browser.js'))) {
-    pkg.browser = {
-      './index.js': './index.browser.js'
+    if ('browser' in pkg) {
+      pkg.browser['./index.js'] = './index.browser.js'
+    } else {
+      pkg.browser = {
+        './index.js': './index.browser.js'
+      }
     }
   }
   if (files.includes(file.replace(/\.js$/, '.native.js'))) {


### PR DESCRIPTION
Previously `dual-publish` would overwrite the `browser` object field in package.json, thus important fields there would get lost and JS bundlers left confused. Now it appends to the `browser` object, as @ai proposed in https://github.com/ai/nanoid/issues/294

[Current `browser` field in `nanoid`](https://unpkg.com/nanoid@3.1.23/package.json): 

```json
"browser": {
  "./index.js": "./index.browser.js"
}
```

After this PR (tested with `npm link` and `node_modules/.bin/dual-publish --check`):

```json
"browser": {
  "./index.js": "./index.browser.js",
  "./index.cjs": "./index.browser.js",
  "./async/index.js": "./async/index.browser.js",
  "./async/index.cjs": "./async/index.browser.js"
}
```